### PR TITLE
Migrate from master and slave terminology

### DIFF
--- a/mysql.py
+++ b/mysql.py
@@ -33,7 +33,7 @@ try:  # ConfigParser
     serialPort = config.get('serial', 'port')
     Debug = config.getboolean('debug', 'debug')
     interval = int(config.get('timeing', 'interval'))
-    slaveAddresses = [int(x) for x in config.get('serial', 'addresses').split(',')]
+    subordinateAddresses = [int(x) for x in config.get('serial', 'addresses').split(',')]
 except configparser.NoOptionError as err:
     print('Error ', err)
     sys.exit

--- a/mysqlkr.py
+++ b/mysqlkr.py
@@ -21,7 +21,7 @@ try:  # ConfigParser
     serialPort = config.get('serial', 'port')
     Debug = config.getboolean('debug', 'debug')
     interval = int(config.get('timeing', 'interval'))
-    slaveAddresses = [int(x) for x in config.get('serial', 'addresses').split(',')]
+    subordinateAddresses = [int(x) for x in config.get('serial', 'addresses').split(',')]
 except configparser.NoOptionError as err:
     print('Error ', err)
     sys.exit

--- a/power.py
+++ b/power.py
@@ -210,8 +210,8 @@ def myslread(fnin_sql, fnin_title, fnin_filename):
 def main_function():
 #    conn = pool.get()
 #    cursor = conn.cursor()
-    maxdevice = max(slaveAddresses)
-    for s in slaveAddresses:
+    maxdevice = max(subordinateAddresses)
+    for s in subordinateAddresses:
         try:
             i = int(s)
             device[i] = pzem.pzem(serialPort, i)
@@ -331,7 +331,7 @@ try:  # ConfigParser
     serialPort = config.get('serial', 'port')
     Debug = config.getboolean('debug', 'debug')
     interval = int(config.get('timeing', 'interval'))
-    slaveAddresses = [int(x) for x in config.get('serial', 'addresses').split(',')]
+    subordinateAddresses = [int(x) for x in config.get('serial', 'addresses').split(',')]
 except configparser.NoOptionError as err:
     print('Error ', err)
     sys.exit
@@ -349,7 +349,7 @@ except configparser.ParsingError as err:
 graphArray = []
 device = {}
 data = {}
-for s in slaveAddresses:
+for s in subordinateAddresses:
     try:
         i = int(s)
         device[i] = pzem.pzem(serialPort, i)

--- a/pzem.py
+++ b/pzem.py
@@ -12,9 +12,9 @@ class pzem(minimalmodbus.Instrument):
     ""","""
 
     # *********************************************************************
-    def __init__(self, serialPort, slaveAddress=1):
+    def __init__(self, serialPort, subordinateAddress=1):
         """ Create monitor device instance """
-        minimalmodbus.Instrument.__init__(self, serialPort, slaveAddress)
+        minimalmodbus.Instrument.__init__(self, serialPort, subordinateAddress)
         self.serial.timeout = 0.1
         self.serial.baudrate = 9600
         self.serial.stopbits = 1
@@ -107,8 +107,8 @@ class pzem(minimalmodbus.Instrument):
         return True
 
     # *********************************************************************
-    def setSlaveAddress(self, address):
-        """Set a new slave address (1 to 247), initially set to 1 from factory.
+    def setSubordinateAddress(self, address):
+        """Set a new subordinate address (1 to 247), initially set to 1 from factory.
         Each device must have a unique address, Max of 31 devices per network."""
         return self.write_register(2, address, 0, 6)
 
@@ -122,13 +122,13 @@ if __name__ == "__main__":
     import time
 
     serialPort = "/dev/ttyUSB0"
-    # Using a slave address other than the factory default of "1".
-    slaveAddress = 2
-    pz = pzem(serialPort, slaveAddress)
+    # Using a subordinate address other than the factory default of "1".
+    subordinateAddress = 2
+    pz = pzem(serialPort, subordinateAddress)
     time.sleep(10)
     print(pz.getPower())
     print(pz.getEnergy())
     print(pz.getVoltage())
-#    pz.setSlaveAddress(2)
+#    pz.setSubordinateAddress(2)
 
 # *********************************************************************


### PR DESCRIPTION
For diversity reasons, it would be nice to try to avoid 'master' and 'slave' terminology in this repository which can be associated to slavery. The master-slave terminology could be problematic for people in several countries which has the history of slavery like Romania, USA and many others. Thank you for considering the proposal. Let me know if any changes in the PR are needed, I would be happy to implement them.